### PR TITLE
Use argument --rm

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,6 @@ So instead of running
 
 You can run
 
-    $ docker run -rm -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer install'
+    $ docker run --rm=true -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer install'
 
 The entrypoint is voluntarily omitted to ease user manipulation in the container in order to have composer generate files with the correct user rights.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ So instead of running
 
     $ composer install
 
-You can run 
+You can run
 
-    $ docker run -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer install'
+    $ docker run -rm -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer install'
 
 The entrypoint is voluntarily omitted to ease user manipulation in the container in order to have composer generate files with the correct user rights.


### PR DESCRIPTION
Each time you run `docker run` a new container is created

``` bash
$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
$ docker run -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer --version'
Composer version a8adbfeb9fc7861deade782938222714168a22a8 2014-09-05 16:28:50
$ docker run -ti -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer --version'
Composer version a8adbfeb9fc7861deade782938222714168a22a8 2014-09-05 16:28:50
$ docker ps -a
CONTAINER ID        IMAGE                           COMMAND                CREATED             STATUS                     PORTS               NAMES
404daa4bc9d1        marmelab/composer-hhvm:latest   bash -c 'hhvm /usr/l   4 seconds ago       Exited (0) 2 seconds ago                       hungry_euclid       
04e9a1345095        marmelab/composer-hhvm:latest   bash -c 'hhvm /usr/l   7 seconds ago       Exited (0) 5 seconds ago                       hungry_carson       
```

On "one shot" container like this one, adding the argument `--rm` delete this temporary container

``` bash
$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
$ docker run -ti --rm -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer --version'
Composer version a8adbfeb9fc7861deade782938222714168a22a8 2014-09-05 16:28:50
$ docker run -ti --rm -v `pwd`:/srv marmelab/composer-hhvm bash -c 'hhvm /usr/local/bin/composer --version'
Composer version a8adbfeb9fc7861deade782938222714168a22a8 2014-09-05 16:28:50
$ docker ps -a
CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
```

see http://docs.docker.com/reference/run/#clean-up-rm
